### PR TITLE
remove _get_indep_borns, and import elaborate_borns_and_epsilon

### DIFF
--- a/aiida_phonopy/common/raw_parsers.py
+++ b/aiida_phonopy/common/raw_parsers.py
@@ -116,7 +116,10 @@ def get_BORN_txt(nac_data, symprec=1.e-5, parameters=None, structure=None):
     from phonopy.structure.cells import get_primitive, get_supercell
     from phonopy.structure.symmetry import Symmetry
     from phonopy.structure.atoms import PhonopyAtoms
-    from phonopy.interface.vasp import get_born_OUTCAR, _get_indep_borns
+    from phonopy.interface.vasp import get_born_OUTCAR
+    from phonopy.interface.vasp import get_born_vasprunxml
+    #from phonopy.interface.vasp import _get_indep_borns #this feature was removed after v1.12.4 of phonopy.
+    from phonopy.structure.symmetry import elaborate_borns_and_epsilon
 
 
     born_charges = nac_data.get_array('born_charges')
@@ -127,11 +130,15 @@ def get_BORN_txt(nac_data, symprec=1.e-5, parameters=None, structure=None):
                          positions=[site.position for site in structure_born.sites],
                          cell=structure_born.cell)
 
-    reduced_borns, epsilon, atom_indices = _get_indep_borns(ucell, born_charges, epsilon,
-                                                            primitive_matrix=None,
-                                                            supercell_matrix=None,
-                                                            symmetrize_tensors=True,
-                                                            symprec=1e-5)
+    reduced_borns, epsilon, atom_indices = elaborate_borns_and_epsilon(
+        ucell,
+        born_charges,
+        epsilon,
+        primitive_matrix=None,
+        supercell_matrix=None,
+        is_symmetry=True,
+        symmetrize_tensors=False,
+        symprec=1.e-5)
 
 
     born_txt = "# epsilon and Z* of atoms "


### PR DESCRIPTION
After upgrading phonopy v.12.2 to higher versions (e.g. v1.12.4 and v1.12.6), I foud the module '_get_indep_borns' had been removed, and the born data parser caused errors.
I fixed this error through adding a module 'elaborate_borns_and_epsilo' to toe raw_parsers.py.

I have tested the  thermal conductivity calculation of silicon using this patch.