### PR TITLE
optimize EDIFF and EDIFFG in vasp relaxations; fix the errors of force calculations in VASP

### DIFF
--- a/aiida_phonopy/common/generate_inputs.py
+++ b/aiida_phonopy/common/generate_inputs.py
@@ -300,6 +300,8 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'EDIFF': 1E-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.'})
+        if 'NPAR' in incar:
+            del incar['NPAR']
 
     if not 'EDIFF' in incar:
         incar.update({'EDIFF': 1.0E-9})

--- a/aiida_phonopy/common/generate_inputs.py
+++ b/aiida_phonopy/common/generate_inputs.py
@@ -248,34 +248,42 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
 
     if type == 'optimize':
         incar.update({
+            'NPAR': 4,
             'PREC': 'Accurate',
             'ISTART': 0,
             'IBRION': 2,
             'ISIF': 3,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
-            'EDIFF': -1e-08,
-            'EDIFFG': -1e-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.',
             'PSTRESS': pressure})  # unit: kb -> kB
 
         if not 'NSW' in incar:
-            incar.update({'NSW': 100})
+            incar.update({'NSW': 300})
+        if  not 'EDIFF' in incar:
+            incar.update({'EDIFF': 1.0E-9})
+        if not 'EDIFFG' in incar:
+            incar.update({'EDIFFG': -1.0E-6})
 
     elif type == 'optimize_constant_volume':
         incar.update({
+            'NPAR': 4,
             'PREC': 'Accurate',
             'ISTART': 0,
             'IBRION': 2,
             'ISIF': 4,
-            'NSW': 100,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
-            'EDIFF': 1e-08,
-            'EDIFFG': -1e-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.'})
+
+        if not 'NSW' in incar:
+            incar.update({'NSW': 300})
+        if  not 'EDIFF' in incar:
+            incar.update({'EDIFF': 1.0E-9})
+        if not 'EDIFFG' in incar:
+            incar.update({'EDIFFG': -1.0E-6})
 
     elif type == 'forces':
         incar.update({
@@ -283,7 +291,7 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'ISYM': 0,
             'ISTART': 0,
             'IBRION': -1,
-            'NSW': 1,
+            'NSW': 0,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
             'EDIFF': 1e-08,
@@ -295,7 +303,7 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'PREC': 'Accurate',
             'LEPSILON': '.TRUE.',
             'ISTART': 0,
-            'IBRION': 1,
+            'IBRION': -1,
             'NSW': 0,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',

--- a/aiida_phonopy/common/generate_inputs.py
+++ b/aiida_phonopy/common/generate_inputs.py
@@ -284,6 +284,7 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'NSW': 0,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
+            'EDIFF': 1E-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.'})
 
@@ -296,6 +297,7 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'NSW': 0,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
+            'EDIFF': 1E-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.'})
 

--- a/aiida_phonopy/common/generate_inputs.py
+++ b/aiida_phonopy/common/generate_inputs.py
@@ -248,7 +248,6 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
 
     if type == 'optimize':
         incar.update({
-            'NPAR': 4,
             'PREC': 'Accurate',
             'ISTART': 0,
             'IBRION': 2,
@@ -261,14 +260,9 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
 
         if not 'NSW' in incar:
             incar.update({'NSW': 300})
-        if  not 'EDIFF' in incar:
-            incar.update({'EDIFF': 1.0E-9})
-        if not 'EDIFFG' in incar:
-            incar.update({'EDIFFG': -1.0E-6})
 
     elif type == 'optimize_constant_volume':
         incar.update({
-            'NPAR': 4,
             'PREC': 'Accurate',
             'ISTART': 0,
             'IBRION': 2,
@@ -280,10 +274,6 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
 
         if not 'NSW' in incar:
             incar.update({'NSW': 300})
-        if  not 'EDIFF' in incar:
-            incar.update({'EDIFF': 1.0E-9})
-        if not 'EDIFFG' in incar:
-            incar.update({'EDIFFG': -1.0E-6})
 
     elif type == 'forces':
         incar.update({
@@ -294,7 +284,6 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'NSW': 0,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
-            'EDIFF': 1e-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.'})
 
@@ -307,9 +296,13 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
             'NSW': 0,
             'LWAVE': '.FALSE.',
             'LCHARG': '.FALSE.',
-            'EDIFF': 1e-08,
             'ADDGRID': '.TRUE.',
             'LREAL': '.FALSE.'})
+
+    if not 'EDIFF' in incar:
+        incar.update({'EDIFF': 1.0E-9})
+    if not 'EDIFFG' in incar:
+        incar.update({'EDIFFG': -1.0E-6})
 
     inputs.parameters = ParameterData(dict=incar)
 

--- a/aiida_phonopy/common/generate_inputs.py
+++ b/aiida_phonopy/common/generate_inputs.py
@@ -316,7 +316,7 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
 
     if 'kpoints_density' in settings.get_dict():
 #        kpoints.set_kpoints_mesh_from_density(settings.dict.kpoints_density)
-        if type == 'born_charges':
+        if type == 'born_charges' or type == 'optimize' or type == 'optimize_constant_volume':
             def multiplier(x): 
                 if x > 0.5:
                     y = 0.3*x
@@ -325,8 +325,8 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
                 elif 0 < x < 0.2:
                     y = 0.7*x
                 return y
-            born_kpoints_density = multiplier(settings.dict.kpoints_density)
-            kpoints.set_kpoints_mesh_from_density(born_kpoints_density)
+            new_kpoints_density = multiplier(settings.dict.kpoints_density)
+            kpoints.set_kpoints_mesh_from_density(new_kpoints_density)
         else:
             kpoints.set_kpoints_mesh_from_density(settings.dict.kpoints_density)
 
@@ -336,10 +336,10 @@ def generate_vasp_params(structure, settings, type=None, pressure=0.0):
         else:
             kpoints_offset = [0.0, 0.0, 0.0]
 
-        if type == 'born_charges':
-            def multiplier(x): return 3*x
-            born_kpoints_mesh_list = list(map(multiplier, settings.dict.kpoints_mesh))
-            kpoints.set_kpoints_mesh(born_kpoints_mesh_list,
+        if type == 'born_charges' or type == 'optimize' or type == 'optimize_constant_volume':
+            def multiplier(x): return 4*x
+            new_kpoints_mesh_list = list(map(multiplier, settings.dict.kpoints_mesh))
+            kpoints.set_kpoints_mesh(new_kpoints_mesh_list,
                                      offset=kpoints_offset)
         else:
             kpoints.set_kpoints_mesh(settings.dict.kpoints_mesh,

--- a/aiida_phonopy/workchains/optimize.py
+++ b/aiida_phonopy/workchains/optimize.py
@@ -143,7 +143,5 @@ class OptimizeStructure(WorkChain):
         self.out('optimized_structure', parse_optimize_calculation(self.ctx.optimize)['output_structure'])
         self.out('optimized_structure_data', parse_optimize_calculation(self.ctx.optimize)['output_data'])
 
-
-
         return
 


### PR DESCRIPTION
Hi, Abel, sorry to bother you on your days-off. You don't urgently to work on it.

From the previous calculations, I observed minor problems, and fixed some of them. 

Here are the instructions about my revisions:

1. Previously in INCAR of VASP for structure relaxation, EDIFF and EDIFFG are both 1E-8, which are not reasonable for VASP since in VASP, it usually requires that EDIFFG is at least 5-10 times of EDIFF.
Here, I  change the default EDIFF and EDIFFG, and make it controllable through launch file by users.

2. There are minor errors in force calculations. NSW must be zero in these self consistent field calculations for supercell structures with displacements. Previous it was 1 which was actually required by DFPT method (IBRION=5...8) for Hessian matrix. We don't need NSW=1 in our displacement method.

Thank you very much and enjoy your holidays.