### PR TITLE
Fix: exclude 'natom' key from data loading in PhonopyParser

### DIFF
--- a/src/aiida_phonopy/parsers/phonopy.py
+++ b/src/aiida_phonopy/parsers/phonopy.py
@@ -335,7 +335,7 @@ class PhonopyParser(Parser):
         import re
 
         # Loading the data
-        data = {key: file[key][:] for key in file.keys()}
+        data = {key: file[key][:] for key in file.keys() if key != 'natom'}
 
         # Initializing the bands object and setting the reciprocal lattice from the unitcell.
         if 'phonopy_data' in self.node.inputs:


### PR DESCRIPTION
Parser was failing in loading bands.hd5 file if _natom_ key is present, since it was expecting to find only arrays but _natom_ has integer value.